### PR TITLE
Use native function to retreive the priv dir

### DIFF
--- a/lib/octicons/storage.ex
+++ b/lib/octicons/storage.ex
@@ -50,6 +50,6 @@ defmodule Octicons.Storage do
   end
 
   defp priv_dir do
-    Path.join([File.cwd!(), "_build", Atom.to_string(Mix.env), "lib", "octicons", "priv"])
+    :code.priv_dir(:octicons)
   end
 end


### PR DESCRIPTION
This uses the proper native function to get the priv_dir for the storage. 
The other breaks in certain cases (eg releases)